### PR TITLE
Bump the expiry and wait periods.

### DIFF
--- a/src/test/java/com/github/fge/msgsimple/provider/LoadingMessageSourceProviderTest.java
+++ b/src/test/java/com/github/fge/msgsimple/provider/LoadingMessageSourceProviderTest.java
@@ -285,11 +285,11 @@ public final class LoadingMessageSourceProviderTest
             .thenReturn(source);
 
         final MessageSourceProvider provider = builder.setLoader(loader)
-            .setExpiryTime(10L, TimeUnit.MILLISECONDS)
+            .setExpiryTime(100L, TimeUnit.MILLISECONDS)
             .setDefaultSource(defaultSource).build();
 
         final MessageSource before = provider.getMessageSource(Locale.ROOT);
-        TimeUnit.MILLISECONDS.sleep(50L);
+        TimeUnit.MILLISECONDS.sleep(500L);
         final MessageSource after = provider.getMessageSource(Locale.ROOT);
 
         verify(loader, times(2)).load(Locale.ROOT);


### PR DESCRIPTION
LoadingMessageSourceProviderTest.expiryCausesFailedLoadsToRetry would fail under modern Gradle because the locale load would take long enough to become cancelled by the periodic cache expiration task. This doesn't fix the model, but makes it less likely to encounter this particular problem in tests.