### PR TITLE
Add errorprone checking to build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,7 @@ language: java
 jdk:
   - openjdk8
   - openjdk11
+install: {}
+script:
+  - ./gradlew assemble check
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,12 +43,17 @@
 //    apply(plugin: "propdeps-eclipse");
 //}
 
+plugins {
+    id("net.ltgt.errorprone") version "0.8.1" apply false
+}
+
 apply(plugin: "java");
 apply(plugin: "maven");
 apply(plugin: "signing");
 apply(plugin: "osgi");
 apply(plugin: "idea");
 apply(plugin: "eclipse");
+apply(plugin: "net.ltgt.errorprone");
 
 apply(from: "project.gradle");
 
@@ -59,6 +64,14 @@ group = "com.github.java-json-tools";
  */
 repositories {
     mavenCentral();
+}
+
+/*
+ * Add errorprone checking.
+ */
+dependencies {
+    errorprone("com.google.errorprone:error_prone_core:2.3.3")
+    errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
 }
 
 /*


### PR DESCRIPTION
Uses https://github.com/google/error-prone and https://github.com/tbroyer/gradle-errorprone-plugin to add checks as warnings. Partial fix for issue #7.