### PR TITLE
Use https for JDK javadoc links.

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -40,8 +40,15 @@ dependencies {
     testCompile(group: "org.mockito", name: "mockito-core", version: "2.28.2");
 }
 
-// FIXME: For some reason, making this https causes OpenJDK 11 to fail.
-javadoc.options.links("http://docs.oracle.com/javase/6/docs/api/");
-javadoc.options.links("https://www.javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/");
-javadoc.options.links("https://java-json-tools.github.io/btf/");
-
+javadoc {
+    options {
+        def currentJavaVersion = org.gradle.api.JavaVersion.current()
+        // FIXME: https://github.com/gradle/gradle/issues/11182
+        if (currentJavaVersion.compareTo(org.gradle.api.JavaVersion.VERSION_1_9) >= 0) {
+            addStringOption("-release", "7");
+        }
+        links("https://docs.oracle.com/javase/7/docs/api/");
+        links("https://www.javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/");
+        links("https://java-json-tools.github.io/btf/");
+    }
+}


### PR DESCRIPTION
Conditionally adds a `--release=7` flag to tell javadoc the source compatibility. This inhibits javadoc in later JDKs erroring out expecting modules when there are none.

See java-json-tools/btf/issues/7.